### PR TITLE
Swap rails dependency with activerecord

### DIFF
--- a/classy_enum.gemspec
+++ b/classy_enum.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ClassyEnum::VERSION
 
-  gem.add_dependency('rails', '>= 3.0')
+  gem.add_dependency('activerecord', '>= 3.0')
 
-  gem.add_development_dependency('rspec-rails', '>= 2.11')
+  gem.add_development_dependency('rspec', '>= 2.11')
   gem.add_development_dependency('sqlite3', '>= 1.3')
   gem.add_development_dependency('json', '>= 1.6')
   gem.add_development_dependency('debugger')

--- a/lib/classy_enum/base.rb
+++ b/lib/classy_enum/base.rb
@@ -8,10 +8,21 @@ module ClassyEnum
     include Translation
     include Collection
 
-    class_attribute :base_class
     attr_accessor :owner, :serialize_as_json, :allow_blank
 
+    def base_class
+      self.class.base_class
+    end
+
     class << self
+      def base_class
+        @base_class ||= superclass.base_class
+      end
+
+      def base_class=(klass)
+        @base_class = klass
+      end
+
       def inherited(klass)
         return if klass.anonymous?
 

--- a/lib/classy_enum/collection.rb
+++ b/lib/classy_enum/collection.rb
@@ -26,6 +26,10 @@ module ClassyEnum
       index <=> other.index
     end
 
+    def enum_options
+      self.class.enum_options
+    end
+
     def self.included(klass)
       klass.extend ClassMethods
     end
@@ -36,7 +40,15 @@ module ClassyEnum
 
       def inherited(klass)
         if self == ClassyEnum::Base
-          klass.class_attribute :enum_options
+          klass.class_eval do
+            def self.enum_options
+              @enum_options ||= superclass.enum_options
+            end
+
+            def self.enum_options=(options)
+              @enum_options = options
+            end
+          end
           klass.enum_options = []
         else
           enum_options << klass

--- a/spec/classy_enum/active_record_spec.rb
+++ b/spec/classy_enum/active_record_spec.rb
@@ -78,7 +78,10 @@ describe DefaultDog do
   context "with invalid breed options" do
     subject { DefaultDog.new(:breed => :fake_breed) }
     it { should_not be_valid }
-    it { should have(1).error_on(:breed) }
+    it 'has an error on :breed' do
+      subject.valid?
+      subject.errors[:breed].size.should eql(1)
+    end
   end
 end
 
@@ -95,7 +98,10 @@ describe "A ClassyEnum that allows blanks" do
   context "with invalid breed options" do
     subject { AllowBlankBreedDog.new(:breed => :fake_breed) }
     it { should_not be_valid }
-    it { should have(1).error_on(:breed) }
+    it 'has an error on :breed' do
+      subject.valid?
+      subject.errors[:breed].size.should eql(1)
+    end
   end
 end
 
@@ -112,7 +118,10 @@ describe "A ClassyEnum that allows nils" do
   context "with invalid breed options" do
     subject { AllowNilBreedDog.new(:breed => :fake_breed) }
     it { should_not be_valid }
-    it { should have(1).error_on(:breed) }
+    it 'has an error on :breed' do
+      subject.valid?
+      subject.errors[:breed].size.should eql(1)
+    end
   end
 end
 
@@ -137,7 +146,10 @@ describe ActiveDog do
         ActiveDog.create!(:name => 'Kitteh', :breed => :husky, :color => :black)
       end
 
-      it { should have(1).error_on(:name) }
+      it 'has an error on :name' do
+        subject.valid?
+        subject.errors[:name].size.should eql(1)
+      end
     end
   end
 

--- a/spec/classy_enum/base_spec.rb
+++ b/spec/classy_enum/base_spec.rb
@@ -55,6 +55,16 @@ describe ClassyEnum::Base do
       }.should raise_error(ClassyEnum::SubclassNameError)
     end
   end
+
+  context '#base_class' do
+    let(:base_class) { double }
+
+    it 'returns class base_class' do
+      enum = ClassyEnumBase.build(:two)
+      enum.class.base_class = base_class
+      enum.base_class.should == base_class
+    end
+  end
 end
 
 describe ClassyEnum::Base, 'Arel visitor' do

--- a/spec/classy_enum/collection_spec.rb
+++ b/spec/classy_enum/collection_spec.rb
@@ -71,6 +71,18 @@ describe ClassyEnum::Collection do
       enum.select(&:odd?).should == [ClassyEnumCollection::One.new, ClassyEnumCollection::Three.new]
     end
   end
+
+  context '#enum_options' do
+    let(:options) { double }
+
+    before do
+      subject.enum_options = options
+    end
+
+    it 'returns class enum_options' do
+      subject.new.enum_options.should == options
+    end
+  end
 end
 
 describe ClassyEnum::Collection, Comparable do

--- a/spec/classy_enum_inheritance_spec.rb
+++ b/spec/classy_enum_inheritance_spec.rb
@@ -1,25 +1,24 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 class ProjectTier < ClassyEnum::Base
-  class_attribute :inherited_properties
+  def self.hello
+    'world'
+  end
 end
 
 class ProjectTier::One < ProjectTier
-  self.inherited_properties = [1,2,3]
 end
 
 class ProjectTier::Two < ProjectTier::One
-  self.inherited_properties += [4,5,6]
 end
 
 describe 'Classy Enum inheritance' do
   it 'should inherit from the previous class' do
-    ProjectTier::One.inherited_properties.should eql([1,2,3])
-    ProjectTier::Two.inherited_properties.should eql([1,2,3,4,5,6])
+    ProjectTier::Two.hello.should eq(ProjectTier::One.hello)
   end
 
   it 'should instantiate the subclass' do
-    ProjectTier::Two.build(:two).should == ProjectTier::Two.new
+    ProjectTier.build(:two).should == ProjectTier::Two.new
   end
 
   it 'should have the right index' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'rubygems'
-require 'rails'
 require 'active_record'
-require 'action_view'
-require 'action_controller'
-require 'rspec/rails'
 require 'classy_enum'
 
 ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")


### PR DESCRIPTION
We are using this gem without rails. I don't see any reason why `rails` is listed as a dependency for this gem. It seems to work just fine with only `activerecord`.
