### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,9 @@ In the above examples, high priority alarms are only emailed if the owning alarm
 @alarm = Alarm.create(priority: :high, enabled: true)
 
 # Should this alarm send an email?
-@alarm.send_email? # => true
+@alarm.priority.send_email? # => true
 @alarm.enabled = false
-@alarm.send_email? # => false
+@alarm.priority.send_email? # => false
 ```
 
 ## Serializing as JSON


### PR DESCRIPTION
I think this is a typo... unless your alarm is delegating its `send_email?` to the priority somehow that you previously haven't explained.
