### PR TITLE
Add class_name as an option to #classy_enum_attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixes long standing issue with default values not being persisted to
   the database. See issue #37.
+* Updates classy_enum_attr method to accept class_name as an argument
 
 ## 3.4.0
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The enum field works like any other model attribute. It can be mass-assigned usi
 
 #### What if your enum class name is not the same as your model's attribute name?
 
-Just provide an optional `enum` argument to declare the attribute name. In this case, the model's attribute is called *alarm_priority*.
+Just provide an optional `enum` or `class_name` argument to declare the attribute name. In this case, the model's attribute is called *alarm_priority*.
 
 ```ruby
 class Alarm < ActiveRecord::Base

--- a/lib/classy_enum/active_record.rb
+++ b/lib/classy_enum/active_record.rb
@@ -53,7 +53,7 @@ module ClassyEnum
     #  # Specifying a default enum value
     #  classy_enum_attr :priority, :default => 'low'
     def classy_enum_attr(attribute, options={})
-      enum              = (options[:enum] || attribute).to_s.camelize.constantize
+      enum              = (options[:enum] || options[:class_name] || attribute).to_s.camelize.constantize
       allow_blank       = options[:allow_blank] || false
       allow_nil         = options[:allow_nil] || false
       serialize_as_json = options[:serialize_as_json] || false

--- a/spec/classy_enum/active_record_spec.rb
+++ b/spec/classy_enum/active_record_spec.rb
@@ -53,7 +53,7 @@ class AllowNilBreedDog < Dog
 end
 
 class OtherDog < Dog
-  classy_enum_attr :other_breed, :enum => 'Breed'
+  classy_enum_attr :other_breed, :class_name => 'Breed'
 end
 
 describe DefaultDog do


### PR DESCRIPTION
wasn't sure how much redundant testing I should throw in
so instead replaced :enum with :class_name to make sure
that the tests still pass
