### PR TITLE
Persistence of Classy Enum arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,24 @@ Priority.each do |priority|
 end
 ```
 
+If you want to persist the collection to a database, use the `classy_enum_array`
+method.
+
+```ruby
+class OperatingSystem < ClassyEnum::Base; end
+class Windows < OperatingSystem; end
+class Linux < OperatingSystem; end
+class MacOsX < OperatingSystem; end
+
+class Product < ActiveRecord::Base
+  classy_enum_array :operating_systems
+end
+
+product = Product.new
+product.operating_systems = [:windows, :linux]
+product.save!
+```
+
 ## Default Enum Value
 
 As with any Active Record attribute, default values can be specified in

--- a/lib/classy_enum/active_record.rb
+++ b/lib/classy_enum/active_record.rb
@@ -102,7 +102,7 @@ module ClassyEnum
     # validation is automatically added to ensure that a value is one of its
     # pre-defined enum members.
     def classy_enum_array(attribute, options={})
-      enum              = (options[:enum] || options[:class_name] || attribute).to_s.camelize.constantize
+      enum              = (options[:enum] || options[:class_name] || ActiveSupport::Inflector.singularize( attribute )).to_s.camelize.constantize
       serialize_as_json = options[:serialize_as_json] || false
       default           = ClassyEnum._normalize_default(options[:default], enum)
 

--- a/lib/classy_enum/active_record.rb
+++ b/lib/classy_enum/active_record.rb
@@ -108,7 +108,7 @@ module ClassyEnum
 
       # Define getter method that returns an array ClassyEnum instance
       define_method attribute do
-        read_attribute( attribute ).split( ',' ).map do |array_value|
+        read_attribute( attribute ).to_s.split( ',' ).map do |array_value|
           enum.build( array_value,
                    :owner             => self,
                    :serialize_as_json => serialize_as_json

--- a/spec/classy_enum/active_record_spec.rb
+++ b/spec/classy_enum/active_record_spec.rb
@@ -13,7 +13,7 @@ ActiveRecord::Schema.define(:version => 2) do
     t.string :breed
     t.string :other_breed
     t.string :another_breed
-    t.string :personality
+    t.string :personalities
   end
 end
 
@@ -225,7 +225,7 @@ class OtherCat < Cat
 end
 
 class PersonableCat < Cat
-  classy_enum_array :personality, :enum => 'Personality'
+  classy_enum_array :personalities
 end
 
 describe DefaultCat do
@@ -269,13 +269,13 @@ describe DefaultCat do
 end
 
 describe PersonableCat do
-  subject { PersonableCat.new(:breed => :tabby, :personality => [:curious, :affectionate] ) }
+  subject { PersonableCat.new(:breed => :tabby, :personalities => [:curious, :affectionate] ) }
 
-  it "should persist and load a diverse personality" do
+  it "should persist and load a diverse personalities" do
     subject.save!
     subject.reload
-    subject.personality[0].should be_a( Personality::Curious )
-    subject.personality[1].should be_a( Personality::Affectionate )
+    subject.personalities[0].should be_a( Personality::Curious )
+    subject.personalities[1].should be_a( Personality::Affectionate )
   end
 end
 

--- a/spec/classy_enum/active_record_spec.rb
+++ b/spec/classy_enum/active_record_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
-ActiveRecord::Schema.define(:version => 1) do
+ActiveRecord::Schema.define(:version => 2) do
   create_table :dogs, :force => true do |t|
     t.string :breed
     t.string :other_breed
@@ -13,6 +13,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string :breed
     t.string :other_breed
     t.string :another_breed
+    t.string :personality
   end
 end
 
@@ -37,6 +38,12 @@ class CatBreed::Abyssian < CatBreed; end
 class CatBreed::Bengal < CatBreed; end
 class CatBreed::Birman < CatBreed; end
 class CatBreed::Persian < CatBreed; end
+class CatBreed::Tabby < CatBreed; end
+
+class Personality < ClassyEnum::Base; end
+class Personality::Curious < Personality; end
+class Personality::Affectionate < Personality; end
+class Personality::Agile < Personality; end
 
 class Dog < ActiveRecord::Base; end
 
@@ -217,6 +224,10 @@ class OtherCat < Cat
   delegate :breed_color, :to => :breed
 end
 
+class PersonableCat < Cat
+  classy_enum_array :personality, :enum => 'Personality'
+end
+
 describe DefaultCat do
   let(:abyssian) { DefaultCat.new(:breed => :abyssian, :color => 'black') }
   let(:persian) { OtherCat.new(:breed => :persian, :color => 'white') }
@@ -256,3 +267,15 @@ describe DefaultCat do
     OtherCat.last.another_breed.should_not be_nil
   end
 end
+
+describe PersonableCat do
+  subject { PersonableCat.new(:breed => :tabby, :personality => [:curious, :affectionate] ) }
+
+  it "should persist and load a diverse personality" do
+    subject.save!
+    subject.reload
+    subject.personality[0].should be_a( Personality::Curious )
+    subject.personality[1].should be_a( Personality::Affectionate )
+  end
+end
+


### PR DESCRIPTION
Classy Enums support Enumerable and do cool things in array.
Classy Enums support cleanly persisting to a database.
Shouldn't Classy Enums support persisting an array of Classy Enums to a database?
Answer: Yes!  Put some chocolate in my peanut butter and some peanut butter in my chocolate!
