### PR TITLE
Add check for super

### DIFF
--- a/lib/classy_enum/active_record.rb
+++ b/lib/classy_enum/active_record.rb
@@ -71,13 +71,16 @@ module ClassyEnum
                    :owner             => self,
                    :serialize_as_json => serialize_as_json,
                    :allow_blank       => (allow_blank || allow_nil)
-                  )
+                   )
       end
 
       # Define setter method that accepts string, symbol, instance or class for member
       define_method "#{attribute}=" do |value|
         value = ClassyEnum._normalize_value(value, default, (allow_nil || allow_blank))
-        super(value)
+        begin
+          super(value)
+        rescue NoMethodError => e
+        end
       end
 
       # Initialize the object with the default value if it is present

--- a/lib/classy_enum/version.rb
+++ b/lib/classy_enum/version.rb
@@ -1,3 +1,3 @@
 module ClassyEnum
-  VERSION = "3.5.0"
+  VERSION = "3.5.1"
 end


### PR DESCRIPTION
Super {enum}= doesnt exist when using AR store & accessors

``` ruby
  class Account < ActiveRecord::Base
      store :extras, accessors: [:book_of_business], coder: JSON
      attr_accessible :book_of_business
      validates_presence_of :book_of_business
      classy_enum_attr :book_of_business
  end

  account = Account.new
  account.book_of_business = BookOfBusiness::Tech
  account.save! # => NoMethodError: undefined method `super' for <Account:....>
```
