### PR TITLE
Return nil when enum set to nil through active record

### DIFF
--- a/classy_enum.gemspec
+++ b/classy_enum.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('activerecord', '>= 3.0')
 
-  gem.add_development_dependency('rspec', '>= 2.11')
+  gem.add_development_dependency('rspec', '= 2.11')
   gem.add_development_dependency('sqlite3', '>= 1.3')
   gem.add_development_dependency('json', '>= 1.6')
 

--- a/lib/classy_enum/base.rb
+++ b/lib/classy_enum/base.rb
@@ -86,6 +86,7 @@ module ClassyEnum
       #  Priority.build(:low) # => Priority::Low.new
       #  Priority.build(:invalid_option) # => :invalid_option
       def build(value, options={})
+        return value if value == nil
         object = find(value)
 
         if object.nil? || (options[:allow_blank] && object.nil?)

--- a/spec/classy_enum/active_record_spec.rb
+++ b/spec/classy_enum/active_record_spec.rb
@@ -113,6 +113,14 @@ describe "A ClassyEnum that allows nils" do
     subject { AllowNilBreedDog.new(:breed => :golden_retriever) }
     it { should be_valid }
     its('breed.allow_blank') { should be_true }
+
+    it 'should return nil when set to nil' do
+      bd = AllowNilBreedDog.new(:breed => nil)
+      expect(bd.breed).to eql(nil)
+      if bd.breed
+        fail 'Expected breed to be falsy'
+      end
+    end
   end
 
   context "with invalid breed options" do

--- a/spec/classy_enum/base_spec.rb
+++ b/spec/classy_enum/base_spec.rb
@@ -29,9 +29,11 @@ describe ClassyEnum::Base do
 
     context 'nil' do
       subject { ClassyEnumBase.build(nil) }
-      it { should be_a(ClassyEnumBase) }
       it { should be_nil }
       it { should be_blank }
+      it { should eql(nil) }
+      it { should == nil }
+      it { fail "Expected to be falsy" if subject }
     end
 
     context 'empty string' do


### PR DESCRIPTION
Hello,

I like this gem a lot, but I ran into issues when migrating existing code to use it. 
It was surprising that the following code didn't work

``` ruby
obj_with_enum = SomeModel.new(:enum_field => nil)
unless obj_with_enum.enum_field
  # This seems like it should be executed, but isn't because enum_field returns an instance of an anonymous proxy class.
  # Ensuring every caller checks for .nil? isn't acceptable since ruby practices equate nil and falsy.
end
```

So to fix, I altered `ClassyEnum::Base#build` to return proper nil when passed nil as the value. Since this method is called with the return from read_attribute, and read_attribute returns nil when the attribute is set to nil, this seemed like the right place to do it. 

Let me know what you think.
