### PR TITLE
Support ActiveRecord store accessors

### DIFF
--- a/lib/classy_enum/active_record.rb
+++ b/lib/classy_enum/active_record.rb
@@ -75,7 +75,7 @@ module ClassyEnum
 
         # Define getter method that returns a ClassyEnum instance
         define_method attribute do
-          enum.build(read_attribute(attribute), owner: self)
+          enum.build(read_attribute(attribute) || super(), owner: self)
         end
 
         # Define setter method that accepts string, symbol, instance or class for member
@@ -109,7 +109,7 @@ module ClassyEnum
       # database and make it searchable.
       if default.present?
         after_initialize do
-          value = read_attribute(attribute)
+          value = read_attribute(attribute) || send(attribute)
 
           if (value.blank? && !(allow_blank || allow_nil)) || (value.nil? && !allow_nil)
             send("#{attribute}=", default)

--- a/spec/classy_enum/active_record_spec.rb
+++ b/spec/classy_enum/active_record_spec.rb
@@ -9,6 +9,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.string :color
     t.string :name
     t.integer :age
+    t.text :properties
   end
 
   create_table :cats, force: true do |t|
@@ -270,6 +271,26 @@ describe Dog, 'with invalid default value' do
     expect {
       Class.new(Dog) { classy_enum_attr :breed, default: :nope }
     }.to raise_error(ClassyEnum::InvalidDefault)
+  end
+end
+
+class Bark < ClassyEnum::Base; end
+class Bark::Quiet < Bark; end;
+class Bark::Loud < Bark; end;
+
+class StoreDog < Dog
+  store :properties, accessors: [:bark]
+  classy_enum_attr :bark
+end
+
+describe StoreDog, rails_3: :broken  do
+  subject { StoreDog.new(bark: :loud) }
+  it { should be_valid }
+
+  it 'persists the enum in a store accessor' do
+    subject.save!
+    subject.reload
+    subject.bark.should be_a(Bark::Loud)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,5 @@ ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:"
 
 RSpec.configure do |config|
   config.color_enabled = true
+  config.filter_run_excluding rails_3: :broken if ActiveRecord::VERSION::MAJOR < 4
 end


### PR DESCRIPTION
I had validation errors trying to use classy_enum with an attribute in a postgresql JSON store. Looks like the issue applies to classy_enum with all store accessors.

I think all we need to do is fallback to super() if read_attribute doesn't.
